### PR TITLE
Wahoo: Insert touch modules at init to fix touch when booting to recovery

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -187,6 +187,8 @@ TW_DEFAULT_LANGUAGE := en
 TW_INCLUDE_NTFS_3G := true
 TW_THEME := portrait_hdpi
 TW_SCREEN_BLANK_ON_BOOT := false
+TW_USE_TOOLBOX := true
+TW_INCLUDE_REPACKTOOLS := true
 
 # exFAT FS Support
 TW_INCLUDE_FUSE_EXFAT := true

--- a/device.mk
+++ b/device.mk
@@ -67,6 +67,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.hardware.rc:recovery/root/init.recovery.$(PRODUCT_HARDWARE).rc \
     $(LOCAL_PATH)/init.hardware.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.$(PRODUCT_HARDWARE).rc \
     $(LOCAL_PATH)/init.hardware.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.wahoo.usb.rc \
+    $(LOCAL_PATH)/recovery/root/sbin/touchdriver.sh:root/sbin/touchdriver.sh \
     $(LOCAL_PATH)/ueventd.hardware.rc:$(TARGET_COPY_OUT_VENDOR)/ueventd.rc \
     $(LOCAL_PATH)/init.elabel.sh:$(TARGET_COPY_OUT_SYSTEM)/bin/init.elabel.sh \
     $(LOCAL_PATH)/init.power.sh:$(TARGET_COPY_OUT_VENDOR)/bin/init.power.sh \

--- a/device.mk
+++ b/device.mk
@@ -67,7 +67,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.hardware.rc:recovery/root/init.recovery.$(PRODUCT_HARDWARE).rc \
     $(LOCAL_PATH)/init.hardware.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.$(PRODUCT_HARDWARE).rc \
     $(LOCAL_PATH)/init.hardware.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.wahoo.usb.rc \
-    $(LOCAL_PATH)/recovery/root/sbin/touchdriver.sh:root/sbin/touchdriver.sh \
+    $(LOCAL_PATH)/recovery/root/sbin/touchdriver.sh:recovery/root/sbin/touchdriver.sh \
     $(LOCAL_PATH)/ueventd.hardware.rc:$(TARGET_COPY_OUT_VENDOR)/ueventd.rc \
     $(LOCAL_PATH)/init.elabel.sh:$(TARGET_COPY_OUT_SYSTEM)/bin/init.elabel.sh \
     $(LOCAL_PATH)/init.power.sh:$(TARGET_COPY_OUT_VENDOR)/bin/init.power.sh \

--- a/init.recovery.hardware.rc
+++ b/init.recovery.hardware.rc
@@ -1,6 +1,7 @@
 on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
+    start touchdriver
 
 on init
     mount configfs none /config
@@ -14,6 +15,12 @@ on init
     mkdir /config/usb_gadget/g1/functions/ffs.adb
     write /config/usb_gadget/g1/os_desc/use 1
     setprop sys.usb.configfs 1
+    
+    service touchdriver /sbin/touchdriver.sh
+    oneshot
+    disabled
+    user root
+    group root
 
 on property:sys.usb.ffs.ready=1
     mkdir /config/usb_gadget/g1/configs/b.1 0777 shell shell

--- a/recovery/root/sbin/touchdriver.sh
+++ b/recovery/root/sbin/touchdriver.sh
@@ -1,0 +1,32 @@
+#!/sbin/sh
+
+suff=$(getprop ro.boot.slot_suffix)
+if [ -z "$suff" ]; then
+	sufx=$(getprop ro.boot.slot)
+	suff="_$sufx"
+fi
+
+venpath="/dev/block/bootdevice/by-name/vendor$suff"
+
+mkdir /v
+mount -t ext4 -o ro "$venpath" /v
+
+tai="/v/lib/modules/touch_core_base.ko"
+taim="/v/lib/modules/ftm4.ko"
+taime="/v/lib/modules/lge_battery.ko"
+
+wall="/v/lib/modules/synaptics_dsx_core_htc.ko"
+walle="/v/lib/modules/htc_battery.ko"
+
+if [[ $(getprop ro.hardware) == "taimen" ]] && [ -f "$tai" ] && [ -f "$taim" ] && [ -f "$taime" ]; then
+  insmod "$tai"
+  insmod "$taim"
+  insmod "$taime"
+ 
+elif [[ $(getprop ro.hardware) == "walleye" ]] && [ -f "$wall" ] && [ -f "$walle" ]; then
+  insmod "$wall"
+  insmod "$walle"
+
+fi
+
+umount /v


### PR DESCRIPTION
Credits @Bigbiff: https://github.com/TeamWin/android_device_google_crosshatch/commit/2121c51881d4b759135e6c160910684a241a723d

